### PR TITLE
Tests and a bug fix

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1142,8 +1142,9 @@ unsigned Lexer::lexCharacter(const char *&CurPtr, char StopQuote,
     // If this is a "high" UTF-8 character, validate it.
     if ((signed char)(CurPtr[-1]) >= 0) {
       if (isPrintable(CurPtr[-1]) == 0)
-        if (EmitDiagnostics)
-          diagnose(CharStart, diag::lex_unprintable_ascii_character);
+        if (!((Modifiers & StringLiteralMultiline) && (CurPtr[-1] == '\t')))
+          if (EmitDiagnostics)
+            diagnose(CharStart, diag::lex_unprintable_ascii_character);
       return CurPtr[-1];
     }
     --CurPtr;

--- a/test/stdlib/NewString.swift
+++ b/test/stdlib/NewString.swift
@@ -334,38 +334,38 @@ print(delimit("""
 print("-12-")
 // Note: The next few tests use physical tab characters, not spaces.
 // FIXME: We also want to check that this emits a warning on the "Nu" line.
-// SKIP-CHECK-NEXT: {{^}}<Twelve
-// SKIP-CHECK-NEXT: {{^}}	Nu
-// SKIP-CHECK-NEXT: {{^}}>
-//print(delimit("""
-//	Twelve
-//\tNu
-//	"""
-//))
+// CHECK-NEXT: {{^}}<Twelve
+// CHECK-NEXT: {{^}}	Nu
+// CHECK-NEXT: {{^}}>
+print(delimit("""
+	Twelve
+\tNu
+	"""
+))
 
 // CHECK: -13-
 print("-13-")
 // FIXME: We also want to check that this emits a warning on the "Xi" line.
-// SKIP-CHECK-NEXT: {{^}}<Thirteen
-// SKIP-CHECK-NEXT: {{^}}	Xi
-// SKIP-CHECK-NEXT: {{^}}>
-//print(delimit("""
-//  Thirteen
-//	Xi
-//  """
-//))
+// CHECK-NEXT: {{^}}<Thirteen
+// CHECK-NEXT: {{^}}	Xi
+// CHECK-NEXT: {{^}}>
+print(delimit("""
+  Thirteen
+	Xi
+  """
+))
 
 // CHECK: -14-
 print("-14-")
 // FIXME: We also want to check that this emits a warning on the "Omicron" line.
-// SKIP-CHECK-NEXT: {{^}}<Fourteen
-// SKIP-CHECK-NEXT: {{^}}  	Pi
-// SKIP-CHECK-NEXT: {{^}}>
-//print(delimit("""
-//    Fourteen
-//  	Pi
-//    """
-//))
+// CHECK-NEXT: {{^}}<Fourteen
+// CHECK-NEXT: {{^}}  	Pi
+// CHECK-NEXT: {{^}}>
+print(delimit("""
+    Fourteen
+  	Pi
+    """
+))
 // Okay, we're done with tabs.
 
 // CHECK: -15-

--- a/test/stdlib/NewString.swift
+++ b/test/stdlib/NewString.swift
@@ -228,6 +228,198 @@ print("<\(zz.0), \(zz.1), \(zz.2), \(zz.3)>")
 s = "interpolated: \(asciiLiteral) \(nonASCIILiteral) \(42) \(3.14) \(true)"
 print("\(repr(s))")
 
+// ===---------- Multiline --------===
+
+func delimit(_ str: String) -> String {
+  return "<\(str)>"
+}
+
+// CHECK: -1-
+print("-1-")
+// CHECK-NEXT: <One Alpha>
+print(delimit("""One Alpha"""))
+
+// CHECK: -2-
+print("-2-")
+// SKIP-CHECK-NEXT: <"Two Beta">
+//print(delimit(""""Two Beta""""))
+
+// CHECK: -3-
+print("-3-")
+// CHECK-NEXT: <Three
+// CHECK-NEXT: Gamma> 
+print(delimit("""Three
+Gamma"""))
+
+// CHECK: -4-
+print("-4-")
+// CHECK-NEXT: <FourDelta>
+print(delimit("""Four\
+Delta"""))
+
+// CHECK: -5-
+print("-5-")
+// CHECK-NEXT: <Five
+// CHECK-NEXT: Epsilon
+// CHECK-NEXT: >
+print(delimit("""Five
+Epsilon\n"""))
+
+// CHECK: -6-
+print("-6-")
+// CHECK-NEXT: {{^}}<Six
+// CHECK-NEXT: {{^}}Zeta
+// CHECK-NEXT: {{^}}>
+print(delimit("""
+    Six
+    Zeta
+    """
+))
+
+// CHECK: -7-
+print("-7-")
+// CHECK-NEXT: {{^}}<Seven
+// CHECK-NEXT: {{^}}Eta>
+print(delimit("""
+    Seven
+    Eta\
+    """
+))
+
+// CHECK: -8-
+print("-8-")
+// CHECK-NEXT: {{^}}<  Eight
+// CHECK-NEXT: {{^}}Iota
+// CHECK-NEXT: {{^}}>
+print(delimit("""
+    Eight
+  Iota
+  """
+))
+
+// CHECK: -9-
+print("-9-")
+// CHECK-NEXT: {{^}}<  Nine
+// CHECK-NEXT: {{^}}  Kappa
+// CHECK-NEXT: {{^}}>
+print(delimit("""
+    Nine
+    Kappa
+  """
+))
+
+// CHECK: -10-
+print("-10-")
+// CHECK-NEXT: {{^}}<    Ten
+// CHECK-NEXT: {{^}}    Lambda
+// CHECK-NEXT: {{^}}>
+print(delimit("""
+    Ten
+    Lambda
+"""))
+
+// CHECK: -11-
+print("-11-")
+// FIXME: We also want to check that this emits a warning on the "Mu" line.
+// CHECK-NEXT: {{^}}<Eleven
+// CHECK-NEXT: {{^}}  Mu
+// CHECK-NEXT: {{^}}>
+print(delimit("""
+    Eleven
+  Mu
+    """
+))
+
+// CHECK: -12-
+print("-12-")
+// Note: The next few tests use physical tab characters, not spaces.
+// FIXME: We also want to check that this emits a warning on the "Nu" line.
+// SKIP-CHECK-NEXT: {{^}}<Twelve
+// SKIP-CHECK-NEXT: {{^}}	Nu
+// SKIP-CHECK-NEXT: {{^}}>
+//print(delimit("""
+//	Twelve
+//\tNu
+//	"""
+//))
+
+// CHECK: -13-
+print("-13-")
+// FIXME: We also want to check that this emits a warning on the "Xi" line.
+// SKIP-CHECK-NEXT: {{^}}<Thirteen
+// SKIP-CHECK-NEXT: {{^}}	Xi
+// SKIP-CHECK-NEXT: {{^}}>
+//print(delimit("""
+//  Thirteen
+//	Xi
+//  """
+//))
+
+// CHECK: -14-
+print("-14-")
+// FIXME: We also want to check that this emits a warning on the "Omicron" line.
+// SKIP-CHECK-NEXT: {{^}}<Fourteen
+// SKIP-CHECK-NEXT: {{^}}  	Pi
+// SKIP-CHECK-NEXT: {{^}}>
+//print(delimit("""
+//    Fourteen
+//  	Pi
+//    """
+//))
+// Okay, we're done with tabs.
+
+// CHECK: -15-
+print("-15-")
+// CHECK-NEXT: {{^}}<    Fifteen
+// CHECK-NEXT: {{^}}    Rho
+// CHECK-NEXT: {{^}}    >
+print(delimit("""\
+    Fifteen
+    Rho
+    """
+))
+
+// CHECK: -16-
+print("-16-")
+// Note: There are trailing spaces on lines in this test which must not be removed.
+// FIXME: We also want to check that this emits a warning on the delimiter line.
+// CHECK-NEXT: {{^}}<    
+// CHECK-NEXT: {{^}}    Sixteen
+// CHECK-NEXT: {{^}}    Sigma
+// CHECK-NEXT: {{^}}    >
+print(delimit("""    
+    Sixteen
+    Sigma
+    """
+))
+
+// CHECK: -17-
+print("-17-")
+// CHECK-NEXT: {{^}}<
+// CHECK-NEXT: {{^}}    Seventeen
+// CHECK-NEXT: {{^}}    Tau>
+print(delimit("""
+    Seventeen
+    Tau"""
+))
+
+// Finally, let's try some syntaxes which should create empty strings:
+
+// CHECK: -18-
+print("-18-")
+// CHECK-NEXT: 1:<>
+// CHECK-NEXT: 2:<>
+// CHECK-NEXT: 3:<>
+// CHECK-NEXT: 4:<>
+print("1:" + delimit(""""""))
+print("2:" + delimit("""\
+"""))
+print("3:" + delimit("""
+"""))
+print("4:" + delimit("""
+    """
+))
+
 // ===---------- Done --------===
 // CHECK-NEXT: Done.
 print("Done.")


### PR DESCRIPTION
I've written tests corresponding to all of the examples in the gallery. ("Corresponding to" because I've changed the strings they generate a little bit to make sure the output of one test doesn't get mistaken for another.)

This actually revealed a bug: Tabs were not permitted because apparently tabs are totally forbidden in string literals. Who knew? I've loosened that restriction for multiline string literals.

It also revealed a possible mistake in the proposal. There, I show this example:

    """"Hello·world!""""

Which I say is equivalent to:

    "Hello·world!"

But that's me thinking like a human, not like a computer. The compiler looks at the character after `!`, sees three `"`, and interprets them as a delimiter. The next `"` is then treated as opening a new string literal, which of course doesn't work and would be invalid even if it did.

Now, we *could* change the proposed matching algorithm to make this work. For instance, we could say that, when the tokenizer sees a `"`, it counts the number of consecutive `"`s, and if there are three or more it takes the last three as a delimiter and treats the earlier ones as string content. But I'm not sure we actually want to do that--it'd probably be simpler to just treat this as invalid. (It might even make sense to treat a `"` immediately after the opening delimiter as invalid, too; I could easily imagine `""""` being a mistake, and if that's really what you mean, you can always escape it.)

Anyway, the rest of this is mergeable.